### PR TITLE
Add styled.js to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "babel.js",
     "src",
     "dist",
-    "lib"
+    "lib",
+    "styled.js"
   ],
   "scripts": {
     "build": "babel src -d lib",


### PR DESCRIPTION
`styled.js` wasn't being published, this adds it to files in package.json.

Related to this, the module field in the package.json goes to src/index.js and since it has flow types it throws errors. We should probably run babel with modules false to generate an es folder or something like that.