### PR TITLE
Add innerRef functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ const H3 = styled.h3`
 function Greeting ({ name }) {
   return <H3>Hello {name}</H3> // red, 16px text
 }
+
+// You can also pass refs down using innerRef
+const H1 = styled('h1')`
+  color: 'red';
+`
+
+function Greeting ({ name }) {
+  // will turn into to <h1 className="generated-className" ref={() => console.log('hello!')}>Hello {name}</h1>
+  return <H1 innerRef={() => console.log('hello!')}>Hello {name}</H1> 
+}
+
 ```
 
 #### attr

--- a/src/styled.js
+++ b/src/styled.js
@@ -18,6 +18,7 @@ export default function (tag, cls, vars = [], content) {
     return React.createElement(
       tag,
       Object.assign({}, props, {
+        ref: props.innerRef,
         className: props.className
           ? className + ' ' + props.className
           : className

--- a/test/__snapshots__/styled.test.js.snap
+++ b/test/__snapshots__/styled.test.js.snap
@@ -108,6 +108,19 @@ exports[`styled higher order component 1`] = `
 />
 `;
 
+exports[`styled innerRef 1`] = `
+.css-H1-dae0kw-kdrkuq {
+  font-size: 12px;
+}
+
+<h1
+  className="css-H1-dae0kw-kdrkuq"
+  innerRef={[Function]}
+>
+  hello world
+</h1>
+`;
+
 exports[`styled name 1`] = `
 .css-FancyH1-1azfbv1-1fzd8kz {
   font-size: 20px;

--- a/test/styled.test.js
+++ b/test/styled.test.js
@@ -167,6 +167,25 @@ describe('styled', () => {
     expect(tree).toMatchSnapshotWithEmotion()
   })
 
+  test('innerRef', () => {
+    const H1 = styled.h1`
+      font-size: 12px;
+    `
+
+    const refFunction = jest.fn()
+
+    const tree = renderer
+      .create(
+        <H1 innerRef={refFunction}>
+          hello world
+        </H1>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshotWithEmotion()
+    expect(refFunction).toBeCalled()
+  })
+
   test('higher order component', () => {
     const fontSize = 20
     const Content = styled('div')`


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Support for `innerRef` being passed down as `ref`.

<!-- Why are these changes necessary? -->
**Why**: To add `ref` functionality to emotioned(?) components. 

<!-- How were these changes implemented? -->
**How**: By adding `innerRef` as prop for child component

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
