### PR TITLE
fix nested selectors when use injectGlobal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ export function injectGlobal (vars: vars, content: () => string[]) {
   const hash = hashArray(src)
   if (!inserted[hash]) {
     inserted[hash] = true
-    sheet.insert(src)
+    src.forEach(r => sheet.insert(r))
   }
 }
 

--- a/test/__snapshots__/inject-global.test.js.snap
+++ b/test/__snapshots__/inject-global.test.js.snap
@@ -3,6 +3,8 @@
 exports[`injectGlobal 1`] = `
 "html {
       background: pink;
+    }html.active {
+      background: red;
     }body {
       color: yellow
        margin: 0;

--- a/test/inject-global.test.js
+++ b/test/inject-global.test.js
@@ -6,6 +6,9 @@ test('injectGlobal', () => {
     html {
       background: pink;
     }
+    html.active {
+      background: red;
+    }
   `
   const bodyStyles = fragment`
     margin: 0;


### PR DESCRIPTION
**What**:

When you want to use nested selectors with `injectGlobal` only the first rule is applied.

Code generated.
```css
html {
  background: pink;
},html.active {
  background: red;
}
```

**Why**:

Proper use of nested rules with `injectGlobal`.

<!-- How were these changes implemented? -->
**How**:

Go through the rules and insert them separately.

**Checklist**:
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete