### PR TITLE
Add size badges to README and size check in CI

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,20 +9,5 @@
     "stage-0",
     "react",
     "flow"
-  ],
-  "env": {
-    "test": {
-      "presets": [
-        [
-          "env",
-          {
-            "loose": true
-          }
-        ],
-        "stage-2",
-        "react",
-        "flow"
-      ]
-    }
-  }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 [![npm version](https://badge.fury.io/js/emotion.svg)](https://badge.fury.io/js/emotion)
 [![Build Status](https://travis-ci.org/tkh44/emotion.svg?branch=master)](https://travis-ci.org/tkh44/emotion)
 [![codecov](https://codecov.io/gh/tkh44/emotion/branch/master/graph/badge.svg)](https://codecov.io/gh/tkh44/emotion)
+![gzip size](http://img.badgesize.io/https://unpkg.com/emotion/dist/DO-NOT-USE.min.js?compression=gzip&label=gzip%20size)
+![size](http://img.badgesize.io/https://unpkg.com/emotion/dist/DO-NOT-USE.min.js?label=size)
 
 
 -   [Install](#install)

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
   "scripts": {
     "build": "babel src -d lib",
     "build:watch": "npm run build -- -w",
-    "umd": "npm-run-all clean -p rollup -p minify:* -s size",
+    "test:size": "npm-run-all clean rollup size",
     "clean": "rimraf dist",
-    "test": "standard src test && jest --coverage --no-cache",
+    "test": "npm-run-all -p lint:check coverage test:size",
+    "coverage": "jest --coverage --no-cache",
+    "lint:check": "standard src test",
     "test:watch": "jest --watch --no-cache",
     "rollup": "rollup -c",
-    "minify:cjs": "uglifyjs $npm_package_main -cm toplevel -o $npm_package_main -p relative --in-source-map ${npm_package_main}.map --source-map ${npm_package_main}.map",
-    "minify:umd": "uglifyjs $npm_package_umd_main -cm -o $npm_package_umd_main -p relative --in-source-map ${npm_package_umd_main}.map --source-map ${npm_package_umd_main}.map",
-    "size": "echo \"Gzipped Size: $(strip-json-comments --no-whitespace $npm_package_umd_main | gzip-size)\"",
-    "release": "npm run test && npm run build && npm version patch && npm publish && git push --tags",
+    "size": "bundlesize",
+    "release": "npm run test && npm run build && npm run rollup && npm version patch && npm publish && git push --tags",
     "lint": "standard --fix",
     "format": "prettier-eslint --write \"src/**/*.js\" \"test/**/*.js\" \"example/**/*.js\" \"jest-utils/**/*.js\""
   },
@@ -37,19 +37,17 @@
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.3",
-    "babel-loader": "^7.1.0",
     "babel-preset-env": "^1.5.1",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
-    "gzip-size-cli": "^2.0.0",
+    "bundlesize": "^0.5.7",
     "jest": "^20.0.4",
     "jest-cli": "^20.0.4",
     "jest-emotion-react": "^0.0.2",
     "jest-glamor-react": "^1.4.0",
     "npm-run-all": "^4.0.2",
     "prettier-eslint-cli": "^4.0.3",
-    "pretty-bytes-cli": "^2.0.0",
     "react": "^15.5.4",
     "react-addons-test-utils": "^15.5.1",
     "react-dom": "^15.5.4",
@@ -57,12 +55,10 @@
     "rimraf": "^2.6.1",
     "rollup": "^0.43.0",
     "rollup-plugin-babel": "^2.7.1",
-    "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-uglify": "^2.0.1",
     "standard": "^10.0.2",
-    "strip-json-comments-cli": "^1.0.1",
-    "uglify-js": "2.8.23",
     "vue": "^2.3.4"
   },
   "author": "Kye Hohenberger",
@@ -100,5 +96,9 @@
   },
   "bugs": {
     "url": "https://github.com/tkh44/emotion/issues"
-  }
+  },
+  "bundlesize": [{
+    "path": "./dist/DO-NOT-USE.min.js",
+    "threshold": "3 Kb"
+  }]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,19 +1,26 @@
-import fs from 'fs'
 import resolve from 'rollup-plugin-node-resolve'
 import commonjs from 'rollup-plugin-commonjs'
 import babel from 'rollup-plugin-babel'
-
-const pkg = JSON.parse(fs.readFileSync('./package.json'))
+import uglify from 'rollup-plugin-uglify'
+import pkg from './package.json'
 
 export default {
-  entry: 'src/styled.js',
+  entry: 'src/react.js',
   external: ['react'],
   exports: 'named',
   globals: { react: 'React' },
   useStrict: false,
   sourceMap: true,
   plugins: [
-    babel(),
+    babel({
+      presets: [
+        ['env', { loose: true, modules: false }],
+        'stage-0',
+        'react',
+        'flow'
+      ],
+      babelrc: false
+    }),
     resolve({
       jsnext: false,
       main: true,
@@ -22,9 +29,10 @@ export default {
     commonjs({
       ignoreGlobal: true,
       include: 'node_modules/**'
-    })
+    }),
+    uglify()
   ],
   targets: [
-    {dest: pkg['umd:main'], format: 'umd', moduleName: pkg.name}
+    { dest: './dist/DO-NOT-USE.min.js', format: 'umd', moduleName: pkg.name }
   ]
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

This adds size badges to the README and a check in CI that `emotion/react`(I chose `emotion/react` since most people will likely use the react version) is less than 3Kb.

I also removed some unused devDependencies and removed the babel config that was specific to tests in the root `.babelrc`.

<!-- Why are these changes necessary? -->
**Why**:

So we can keep track of the size of emotion when PRs are submitted and so people who want to use emotion can see how small it is.

<!-- How were these changes implemented? -->
**How**:

I made the rollup config build a umd build to `dist/DO-NOT-USE.min.js`. I also added the `bundlesize` module which checks if a file's gzip size is below a certain threshold and integrates with GitHub statuses.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A

<!-- feel free to add additional comments -->

We have to set up the GitHub status integration.(We don't NEED to do this but it might be nice to show us in the GitHub UI)
https://www.npmjs.com/package/bundlesize#build-status
