### PR TITLE
Optimize: `index.js`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ function deconstruct (selector, styles, media) {
       decs.push(createDec(key, value))
     } else if (Array.isArray(value)) {
       forEach(value, val => decs.push(createDec(key, val)))
-    } else if (/^:/.test(key)) {
+    } else if (key.charCodeAt(0) === 58) {
       forEach(deconstruct(selector + key, value, media), r => rules.push(r))
     } else if (/^@media/.test(key)) {
       forEach(deconstruct(selector, value, key), r => rules.push(r))

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ function deconstruct (selector, styles, media) {
       forEach(value, val => decs.push(createDec(key, val)))
     } else if (key.charCodeAt(0) === 58) {
       forEach(deconstruct(selector + key, value, media), r => rules.push(r))
-    } else if (/^@media/.test(key)) {
+    } else if (key.indexOf('@media') !== -1) {
       forEach(deconstruct(selector, value, key), r => rules.push(r))
     } else {
       forEach(deconstruct(selector + ' ' + key, value, media), r => rules.push(r))

--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ function hyphenate (str) {
 }
 
 function addPx (prop, value) {
-  if (typeof value !== 'number' || unitlessProps[prop]) return value
+  if (typeof value !== 'number' || unitlessProps[prop] !== void 0) return value
   return value + 'px'
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 // @flow
-import map from '@arr/map'
 import forEach from '@arr/foreach'
 import { StyleSheet } from './sheet'
 import { hashArray, hashObject } from './hash'
@@ -55,10 +54,9 @@ export function css (classes: string[], vars: vars, content: () => string[]) {
     if (!inserted[hash]) {
       inserted[hash] = true
       const rgx = new RegExp(classes[0], 'gm')
-      forEach(
-        map(src, r => r.replace(rgx, `${classes[0]}-${hash}`)),
-        r => sheet.insert(r)
-      )
+      forEach(src, r => {
+        sheet.insert(r.replace(rgx, `${classes[0]}-${hash}`))
+      })
     }
     return `${classes[0]}-${hash} ${computedClassName}`
   }

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,11 @@ function values (cls: string, vars: vars) {
   if (inserted[hash]) {
     return varCls
   }
-  let src = map(vars, (val: inputVar, i: number) => `--${cls}-${i}: ${val}`).join('; ')
+  let src = ''
+  forEach(vars, (val: inputVar, i: number) => {
+    src && (src += '; ')
+    src += `--${cls}-${i}: ${val}`
+  })
   sheet.insert(`.${varCls} {${src}}`)
   inserted[hash] = true
 

--- a/src/index.js
+++ b/src/index.js
@@ -52,8 +52,9 @@ export function css (classes: string[], vars: vars, content: () => string[]) {
 
     if (!inserted[hash]) {
       inserted[hash] = true
+      const rgx = new RegExp(classes[0], 'gm')
       forEach(
-        map(src, r => r.replace(new RegExp(classes[0], 'gm'), `${classes[0]}-${hash}`)),
+        map(src, r => r.replace(rgx, `${classes[0]}-${hash}`)),
         r => sheet.insert(r)
       )
     }

--- a/src/index.js
+++ b/src/index.js
@@ -120,23 +120,14 @@ function deconstruct (selector, styles, media) {
 
     if (type === 'number' || type === 'string') {
       decs.push(createDec(key, value))
-      continue
     } else if (Array.isArray(value)) {
-      forEach(value, val => {
-        decs.push(createDec(key, val))
-      })
-      continue
+      forEach(value, val => decs.push(createDec(key, val)))
     } else if (/^:/.test(key)) {
       forEach(deconstruct(selector + key, value, media), r => rules.push(r))
-      continue
     } else if (/^@media/.test(key)) {
       forEach(deconstruct(selector, value, key), r => rules.push(r))
-      continue
     } else {
-      forEach(deconstruct(selector + ' ' + key, value, media), r =>
-        rules.push(r)
-      )
-      continue
+      forEach(deconstruct(selector + ' ' + key, value, media), r => rules.push(r))
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,9 +41,11 @@ export function css (classes: string[], vars: vars, content: () => string[]) {
     classes = [classes]
   }
 
-  const computedClassName = map(classes, (cls): string => typeof cls === 'string' ? cls : objStyle(cls))
-    .join(' ')
-    .trim()
+  let computedClassName = ''
+  forEach(classes, (cls): string => {
+    computedClassName && (computedClassName += ' ')
+    computedClassName += typeof cls === 'string' ? cls : objStyle(cls)
+  })
 
   if (content) {
     // inline mode
@@ -82,9 +84,7 @@ export function keyframes (kfm: string, src: string[]) {
   const animationName = `${kfm}-${hash}`
   if (!inserted[hash]) {
     inserted[hash] = true
-    forEach(src, r => {
-      sheet.insert(`@keyframes ${animationName} ${r}`)
-    })
+    forEach(src, r => sheet.insert(`@keyframes ${animationName} ${r}`))
   }
   return animationName
 }

--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ function hyphenate (str) {
 }
 
 function addPx (prop, value) {
-  if (typeof value !== 'number' || unitlessProps[prop] !== void 0) return value
+  if (typeof value !== 'number' || unitlessProps[prop] !== undefined) return value
   return value + 'px'
 }
 

--- a/test/__snapshots__/react.test.js.snap
+++ b/test/__snapshots__/react.test.js.snap
@@ -143,17 +143,18 @@ exports[`styled composes with objects 1`] = `
   font-size: 1.333em;
 }
 
-.css-1olphq9 
-    @media only screen and (-webkit-min-device-pixel-ratio: 1.5),
-only screen and (min--moz-device-pixel-ratio: 1.5),
-only screen and (-o-min-device-pixel-ratio: 1.5/1),
-only screen and (min-resolution: 144dpi),
-only screen and (min-resolution: 1.5dppx) {
-  font-size: 1.4323121856191332em;
-}
-
 .css-H1-zejj71-1ym7xv {
   font-size: 3.157334518321em;
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio: 1.5),
+    only screen and (min--moz-device-pixel-ratio: 1.5),
+    only screen and (-o-min-device-pixel-ratio: 1.5/1),
+    only screen and (min-resolution: 144dpi),
+    only screen and (min-resolution: 1.5dppx) {
+  .css-1olphq9 {
+    font-size: 1.4323121856191332em;
+  }
 }
 
 <h1


### PR DESCRIPTION
**What**:

* Performance updates: 
  * `join()`s are slower than string concatenation
  * fixed `new RegExp(classes[0])` -- was re-creating per loop
  * replace `RegExp.test` with 38-52X faster alternatives
  * remove problematic implicit casting -- de-opts function

* Bugfix: Long/multi-`@media` blocks were not caught by RegExp pattern. Resulted in inverted (ergo, invalid) CSS rule.
  - _Updated Jest snapshot as a result of this!_

**Why**:

* Requested // it's fun
* Fix the bug 😅 

