### PR TITLE
Move theming into its own file

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,7 +1,7 @@
 ## Theming
 
 ```jsx
-import { ThemeProvider, withTheme } from 'emotion/react'
+import { ThemeProvider, withTheme } from 'emotion/react/theming'
 ```
 
 Theming is provided by the theming library. 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "src",
     "dist",
     "lib",
-    "react.js",
+    "react",
     "server.js",
     "vue.js",
     "dist/DO-NOT-USE.min.js"

--- a/react.js
+++ b/react.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/react')

--- a/react/index.js
+++ b/react/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../lib/react')

--- a/react/theming.js
+++ b/react/theming.js
@@ -1,0 +1,1 @@
+module.exports = require('../lib/react/theming')

--- a/src/react/constants.js
+++ b/src/react/constants.js
@@ -1,0 +1,1 @@
+export const CHANNEL = '__emotion__'

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -1,13 +1,9 @@
 import { Component, createElement as h } from 'react'
-import { createTheming } from 'theming'
 import PropTypes from 'prop-types'
 import map from '@arr/map'
-import { css } from './index'
-import { omit } from './utils'
-
-const theming = createTheming('__emotion__')
-const { channel: CHANNEL, withTheme, ThemeProvider } = theming
-export { CHANNEL, withTheme, ThemeProvider }
+import { css } from '../index'
+import { omit } from '../utils'
+import { CHANNEL } from './constants'
 
 export default function (tag, cls, vars = [], content) {
   if (!tag) {

--- a/src/react/theming.js
+++ b/src/react/theming.js
@@ -1,0 +1,6 @@
+import { createTheming } from 'theming'
+import { CHANNEL } from './constants'
+
+const theming = createTheming(CHANNEL)
+const { withTheme, ThemeProvider } = theming
+export { CHANNEL, withTheme, ThemeProvider }

--- a/test/react.test.js
+++ b/test/react.test.js
@@ -3,7 +3,8 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { matcher, serializer } from '../jest-utils'
 import { css } from '../src/index'
-import styled, { ThemeProvider } from '../src/react'
+import styled from '../src/react'
+import { ThemeProvider } from '../src/react/theming'
 
 import { lighten, hiDPI, modularScale, borderWidth } from 'polished'
 


### PR DESCRIPTION
⚠️ Breaking Change ⚠️ 
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Move `ThemeProvider` and `withTheme` exports to `emotion/react/theming`.

<!-- Why are these changes necessary? -->
**Why**:

Because not everyone wants theming and this doesn't force people to include it if they don't want it.

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
