### PR TITLE
Fix broken path for `Usage with CSS Modules`

### DIFF
--- a/docs/css-modules.md
+++ b/docs/css-modules.md
@@ -6,8 +6,8 @@ emotion works well with CSS Modules but it requires a bit of configuration.
 2. Add another object to your `modules.use` with your css loaders but with CSS Modules disabled and set the test field to the same regex as above `/emotion\.css$/`.
 
 
-- [Example webpack config](example/webpack.config.js)
-- [Example usage of CSS Modules with emotion](example/src/markdown/index.js)
+- [Example webpack config](../example/webpack.config.js)
+- [Example usage of CSS Modules with emotion](../example/src/markdown/index.js)
 
 ### attr
 

--- a/docs/inject-global.md
+++ b/docs/inject-global.md
@@ -4,8 +4,8 @@
 import { injectGlobal } from 'emotion'
 
 injectGlobal`
-	* {
-		box-sizing: border-box;
-	}
+  * {
+    box-sizing: border-box;
+  }
 `
 ```


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Fix broken path for `Usage with CSS Modules`

<!-- Why are these changes necessary? -->
**Why**: Link broken (I think caused after 99e2799 )

<!-- How were these changes implemented? -->
**How**: `../`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests
- [ ] Code complete

<!-- feel free to add additional comments -->
---
Also changed indentation from 4 to 2 for purely consistency reasons on `inject-global.md`. Adding `.editorconfig` will solve inconsistencies as GitHub will render according to the configuration