### PR TITLE
Expose 'emotion' named exports on 'emotion/react' and 'emotion/server'

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -8,6 +8,7 @@ import { omit } from './utils'
 const theming = createTheming('__emotion__')
 const { channel: CHANNEL, withTheme, ThemeProvider } = theming
 export { CHANNEL, withTheme, ThemeProvider }
+export { flush, css, injectGlobal, fontFace, keyframes, hydrate, objStyle } from './index'
 
 export default function (tag, cls, vars = [], content) {
   if (!tag) {

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,8 @@ import { keys } from './utils'
 
 const RGX = /css(?:[a-zA-Z0-9-]*)-([a-zA-Z0-9]+)/gm
 
+export { flush, css, injectGlobal, fontFace, keyframes, hydrate, objStyle } from './index'
+
 export function extractCritical (html) {
   // parse out ids from html
   // reconstruct css/rules/cache to pass


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Expose base 'emotion' named exports on react and server modules

<!-- Why are these changes necessary? -->
**Why**: Prevents two import statements in common scenarios (a la `react-apollo`)

<!-- How were these changes implemented? -->
**How**: Without testing (sorry - should work straight up)

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
