### PR TITLE
use extractCritical to set css-vars inline

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -3,7 +3,8 @@ import filter from '@arr/filter.mutate'
 import { sheet, inserted } from './index'
 import { keys } from './utils'
 
-const RGX = /css(?:[a-zA-Z0-9-]*)-([a-zA-Z0-9]+)/gm
+const RGX = /(?:css|vars)(?:[a-zA-Z0-9-]*)-([a-zA-Z0-9]+)/gm
+const VAR_RGX = /(?:vars)(?:[a-zA-Z0-9-]*)-([a-zA-Z0-9]+)/gm
 
 export { flush, css, injectGlobal, fontFace, keyframes, hydrate, objStyle } from './index'
 
@@ -20,8 +21,18 @@ export function extractCritical (html) {
   }
 
   o.rules = filter(sheet.sheet.cssRules.slice(), x => {
-    let match = RGX.exec(x.cssText)
-    return match == null || ids[match[1]] || false
+    // check for vars match first because it is a different format
+    // e.g. .vars-176qc2r {--css-Home-1wjhkv7-0: 0; --css-Home-1wjhkv7-1: 1}
+    const varMatch = VAR_RGX.exec(x.cssText)
+
+    if (varMatch == null) {
+      // no vars, proceed with normal css check
+      const cssMatch = RGX.exec(x.cssText)
+
+      return cssMatch == null || ids[cssMatch[1]] || false
+    }
+
+    return ids[varMatch[1]] || false
   })
 
   o.ids = filter(keys(inserted), id => !!ids[id])


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
This PR adds css-vars to extractCritical so their initial values may be set inline (when in `extract` mode). Discussed in #147.

<!-- How were these changes implemented? -->
**How**:
Started with @mitchellhamilton's regex substitute, but needed to account for `vars-` strings a bit differently. Since the regex was greedy, for a string like

```css
.vars-176qc2r {--css-Home-1wjhkv7-0: 0; --css-Home-1wjhkv7-1: 1}
```

, the matcher would grab a `css-` string instead of the desired `vars-`. We could change our regex to be lazy with something like `/(?:css|vars)(?:[a-zA-Z0-9-]*?)-([a-zA-Z0-9]+?)/gm`, but that seems brittle. Surely there'll be a time when `css-` will be shorter than the `vars-`.

So, this implementation checks for `vars-` first, then moves on to the normal `css-` check.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [ ] Code complete

<!-- feel free to add additional comments -->
