### PR TITLE
Fix 'arr/*' imports

### DIFF
--- a/src/babel-utils.js
+++ b/src/babel-utils.js
@@ -1,5 +1,5 @@
 import { keys } from './utils'
-import forEach from '@arr/foreach'
+const forEach = require('@arr/foreach')
 
 export function getIdentifierName (path, t) {
   const parent = path.findParent(p => p.isVariableDeclarator())

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // @flow
-import forEach from '@arr/foreach'
 import { StyleSheet } from './sheet'
 import { hashArray, hashObject } from './hash'
+const forEach = require('@arr/foreach')
 
 export const sheet = new StyleSheet()
 sheet.inject()

--- a/src/macro.js
+++ b/src/macro.js
@@ -5,7 +5,7 @@ import {
 } from './babel'
 import { buildMacroRuntimeNode, addRuntimeImports } from './babel-utils'
 import { injectGlobal, fontFace } from './inline'
-import forEach from '@arr/foreach'
+const forEach = require('@arr/foreach')
 import { keys } from './utils'
 
 module.exports = function macro ({ references, state, babel: { types: t } }) {

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -1,6 +1,6 @@
 import { Component, createElement as h } from 'react'
 import PropTypes from 'prop-types'
-import map from '@arr/map'
+const map = require('@arr/map')
 import { css } from '../index'
 import { omit } from '../utils'
 import { CHANNEL } from './constants'

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,5 @@
-import forEach from '@arr/foreach'
-import filter from '@arr/filter.mutate'
+const forEach = require('@arr/foreach')
+const filter = require('@arr/filter.mutate')
 import { sheet, inserted } from './index'
 import { keys } from './utils'
 


### PR DESCRIPTION
Fixes issue reported in Slack... short-term solution. Ideally, we'd find a Babel plugin that ignores the `"module"` entries & instead loads the `"main"` entries, which are CommonJS.

I've [asked for help](https://twitter.com/lukeed05/status/887060026220716032) and insights -- hopefully something comes up so that you can keep the `import` statements.
