### PR TITLE
Move fbjs imports for warning and camelizeStyleName

### DIFF
--- a/src/glamor/CSSPropertyOperations/index.js
+++ b/src/glamor/CSSPropertyOperations/index.js
@@ -9,15 +9,15 @@
  * @providesModule CSSPropertyOperations
  */
 
-import camelizeStyleName from 'fbjs/lib/camelizeStyleName'
 import dangerousStyleValue from './dangerousStyleValue'
 import hyphenateStyleName from 'fbjs/lib/hyphenateStyleName'
 import memoizeStringOnly from 'fbjs/lib/memoizeStringOnly'
-import warning from 'fbjs/lib/warning'
 
 export const processStyleName = memoizeStringOnly(hyphenateStyleName)
 
 if (process.env.NODE_ENV !== 'production') {
+  const warning = require('fbjs/lib/warning')
+  const camelizeStyleName = require('fbjs/lib/camelizeStyleName')
   // 'msTransform' is correct, but the other prefixes should be capitalized
   let badVendoredStyleNamePattern = /^(?:webkit|moz|o)[A-Z]/
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Move the imports for `warning` and `camelizeStyleName` into a `if (process.env.NODE_ENV !== 'production')` block.

<!-- Why are these changes necessary? -->
**Why**:

So they're not included in production.

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
