### PR TITLE
Filter props on composed components

### DIFF
--- a/test/__snapshots__/react.test.js.snap
+++ b/test/__snapshots__/react.test.js.snap
@@ -547,23 +547,6 @@ exports[`styled prop filtering on composed styled components that are string tag
 </a>
 `;
 
-exports[`styled prop filtering on styled components that are string tags 1`] = `
-.glamor-2 {
-  background-color: hotpink;
-  color: green;
-}
-
-<a
-  aria-label="some label"
-  className="glamor-0 glamor-1 glamor-2"
-  data-wow="value"
-  href="link"
-  is={true}
->
-  hello world
-</a>
-`;
-
 exports[`styled random expressions 1`] = `
 .glamor-1 {
   font-size: 1rem;

--- a/test/__snapshots__/react.test.js.snap
+++ b/test/__snapshots__/react.test.js.snap
@@ -210,7 +210,6 @@ exports[`styled composes 1`] = `
 
 <h1
   className="glamor-0 glamor-1 legacy__class glamor-2"
-  scale={2}
 >
   hello world
 </h1>
@@ -259,7 +258,6 @@ exports[`styled composes with objects 1`] = `
 
 <h1
   className="glamor-0 glamor-1 legacy__class glamor-2"
-  scale={2}
 >
   hello world
 </h1>
@@ -302,7 +300,6 @@ exports[`styled function in expression 1`] = `
 
 <h1
   className="glamor-0 glamor-1 legacy__class glamor-2"
-  scale={2}
 >
   hello world
 </h1>
@@ -525,6 +522,40 @@ exports[`styled prop filtering 1`] = `
 <a
   aria-label="some label"
   className="glamor-0 glamor-1"
+  data-wow="value"
+  href="link"
+  is={true}
+>
+  hello world
+</a>
+`;
+
+exports[`styled prop filtering on composed styled components that are string tags 1`] = `
+.glamor-2 {
+  background-color: hotpink;
+  color: green;
+}
+
+<a
+  aria-label="some label"
+  className="glamor-0 glamor-1 glamor-2"
+  data-wow="value"
+  href="link"
+  is={true}
+>
+  hello world
+</a>
+`;
+
+exports[`styled prop filtering on styled components that are string tags 1`] = `
+.glamor-2 {
+  background-color: hotpink;
+  color: green;
+}
+
+<a
+  aria-label="some label"
+  className="glamor-0 glamor-1 glamor-2"
   data-wow="value"
   href="link"
   is={true}

--- a/test/macro/__snapshots__/react.test.js.snap
+++ b/test/macro/__snapshots__/react.test.js.snap
@@ -69,7 +69,6 @@ exports[`styled composes 1`] = `
 
 <h1
   className="glamor-0 glamor-1 glamor-2"
-  scale={2}
 >
   hello world
 </h1>
@@ -119,7 +118,6 @@ exports[`styled composes with objects 1`] = `
 
 <h1
   className="glamor-0 glamor-1 glamor-2"
-  scale={2}
 >
   hello world
 </h1>
@@ -144,7 +142,6 @@ exports[`styled function in expression 1`] = `
 
 <h1
   className="glamor-0 glamor-1 glamor-2"
-  scale={2}
 >
   hello world
 </h1>

--- a/test/react.test.js
+++ b/test/react.test.js
@@ -607,6 +607,31 @@ describe('styled', () => {
 
     expect(tree).toMatchSnapshot()
   })
+  test('prop filtering on composed styled components that are string tags', () => {
+    const BaseLink = styled.a`background-color: hotpink;`
+    const Link = styled(BaseLink)`color: green;`
+
+    const tree = renderer
+      .create(
+        <Link
+          a
+          b
+          wow
+          prop
+          filtering
+          is
+          cool
+          aria-label="some label"
+          data-wow="value"
+          href="link"
+        >
+          hello world
+        </Link>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
   test('throws if undefined is passed as the component', () => {
     expect(
       () => styled(undefined)`display: flex;`


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Filter props on components that are styled components that have string tags. For example the props on `Link` will now be filtered.
```jsx
const BaseLink = styled.a`background-color: hotpink;`
const Link = styled(BaseLink)`color: green;`
```
<!-- Why are these changes necessary? -->
**Why**:

Because otherwise there will be unknown prop warnings on composed styled components.

<!-- How were these changes implemented? -->
**How**:

Move the declaration of `spec` to be before `Styled` is defined and check wether the first spec's tag is a string instead of just the tag.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->

This is also a bit smaller now. 🎉 
