### PR TITLE
Pass filename to PostCSS correctly

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -16,7 +16,7 @@ import { hashArray } from './hash'
 import cssProps from './css-prop'
 import ASTObject from './ast-object'
 
-function getFilename(path) {
+export function getFilename(path) {
   return path.hub.file.opts.filename === 'unknown'
     ? ''
     : path.hub.file.opts.filename
@@ -203,7 +203,7 @@ export function buildStyledObjectCallExpression(path, state, identifier, t) {
 
 function buildProcessedStylesFromObjectAST(objectAST, path, t) {
   if (t.isObjectExpression(objectAST)) {
-    return ASTObject.fromAST(objectAST, t).toAST()
+    return ASTObject.fromAST(objectAST, t, path).toAST()
   }
   if (t.isArrayExpression(objectAST)) {
     return t.arrayExpression(

--- a/src/parser.js
+++ b/src/parser.js
@@ -55,7 +55,7 @@ export function parseCSS(
     }
   })
 
-  const styles = expandCSSFallbacks(prefixer(postcssJs.objectify(root)))
+  const styles = expandCSSFallbacks(prefixer(root))
 
   return {
     styles,

--- a/test/__snapshots__/css.test.js.snap
+++ b/test/__snapshots__/css.test.js.snap
@@ -17,8 +17,6 @@ exports[`css composes 1`] = `
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
   justify-content: center;
 }
 
@@ -35,8 +33,6 @@ exports[`css composes with objects 1`] = `
   display: block;
   width: 30px;
   height: calc(40vw - 50px);
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
   justify-content: center;
 }
 
@@ -62,8 +58,6 @@ exports[`css composes with objects 1`] = `
 
 exports[`css composes with undefined values 1`] = `
 .glamor-0 {
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
   justify-content: center;
 }
 

--- a/test/babel/__snapshots__/css.test.js.snap
+++ b/test/babel/__snapshots__/css.test.js.snap
@@ -58,8 +58,6 @@ const cls1 = css({
 const cls2 = /*#__PURE__*/css([cls1], [], function createEmotionStyledRules() {
   return [{
     'height': '20',
-    'WebkitBoxPack': 'center',
-    'msFlexPack': 'center',
     'justifyContent': 'center'
   }];
 });"

--- a/test/babel/css-prop.test.js
+++ b/test/babel/css-prop.test.js
@@ -5,6 +5,7 @@ import * as fs from 'fs'
 jest.mock('fs')
 
 fs.existsSync.mockReturnValue(true)
+fs.statSync.mockReturnValue({ isFile: () => false })
 
 describe('babel css prop', () => {
   test('basic with extractStatic', () => {

--- a/test/babel/css.test.js
+++ b/test/babel/css.test.js
@@ -4,6 +4,7 @@ import * as fs from 'fs'
 jest.mock('fs')
 
 fs.existsSync.mockReturnValue(true)
+fs.statSync.mockReturnValue({ isFile: () => false })
 
 describe('babel css', () => {
   describe('inline', () => {

--- a/test/babel/font-face.test.js
+++ b/test/babel/font-face.test.js
@@ -4,6 +4,7 @@ import * as fs from 'fs'
 jest.mock('fs')
 
 fs.existsSync.mockReturnValue(true)
+fs.statSync.mockReturnValue({ isFile: () => false })
 
 describe('fontFace babel', () => {
   describe('inline', () => {

--- a/test/babel/fs.test.js
+++ b/test/babel/fs.test.js
@@ -4,6 +4,7 @@ import touch from 'touch'
 import emotionPlugin from '../../src/babel'
 
 jest.mock('fs').mock('touch')
+fs.statSync.mockReturnValue({ isFile: () => false })
 
 const basic = `
 css\`

--- a/test/babel/inject-global.test.js
+++ b/test/babel/inject-global.test.js
@@ -4,6 +4,7 @@ import * as fs from 'fs'
 jest.mock('fs')
 
 fs.existsSync.mockReturnValue(true)
+fs.statSync.mockReturnValue({ isFile: () => false })
 
 describe('babel injectGlobal', () => {
   describe('inline', () => {

--- a/test/babel/keyframes.test.js
+++ b/test/babel/keyframes.test.js
@@ -4,6 +4,7 @@ import * as fs from 'fs'
 jest.mock('fs')
 
 fs.existsSync.mockReturnValue(true)
+fs.statSync.mockReturnValue({ isFile: () => false })
 
 describe('babel keyframes', () => {
   describe('inline', () => {

--- a/test/babel/styled.test.js
+++ b/test/babel/styled.test.js
@@ -5,6 +5,7 @@ import * as fs from 'fs'
 jest.mock('fs')
 
 fs.existsSync.mockReturnValue(true)
+fs.statSync.mockReturnValue({ isFile: () => false })
 
 describe('babel styled component', () => {
   describe('inline', () => {

--- a/test/browserslist/__snapshots__/babel.test.js.snap
+++ b/test/browserslist/__snapshots__/babel.test.js.snap
@@ -4,7 +4,14 @@ exports[`babel css inline css basic 1`] = `
 "
 /*#__PURE__*/css([], [], function createEmotionStyledRules() {
         return [{
-                \\"display\\": \\"-webkit-box; display: -ms-flexbox; display: flex\\"
+                \\"display\\": \\"flex\\"
         }];
+});"
+`;
+
+exports[`babel css inline css object 1`] = `
+"
+css({
+  'display': 'flex'
 });"
 `;

--- a/test/browserslist/__snapshots__/css.test.js.snap
+++ b/test/browserslist/__snapshots__/css.test.js.snap
@@ -2,8 +2,18 @@
 
 exports[`prefixing css 1`] = `
 .glamor-0 {
-  display: -webkit-box;
-  display: -ms-flexbox;
+  display: flex;
+}
+
+<div
+  className="glamor-0"
+>
+  hello world
+</div>
+`;
+
+exports[`prefixing object 1`] = `
+.glamor-0 {
   display: flex;
 }
 
@@ -16,8 +26,6 @@ exports[`prefixing css 1`] = `
 
 exports[`prefixing styled 1`] = `
 .glamor-1 {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 

--- a/test/browserslist/babel.test.js
+++ b/test/browserslist/babel.test.js
@@ -15,5 +15,17 @@ describe('babel css', () => {
       })
       expect(code).toMatchSnapshot()
     })
+    test('css object', () => {
+      const basic = `
+        css({
+          display: 'flex'
+        })`
+      const { code } = babel.transform(basic, {
+        plugins: [[plugin]],
+        filename: __filename,
+        babelrc: false
+      })
+      expect(code).toMatchSnapshot()
+    })
   })
 })

--- a/test/browserslist/css.test.js
+++ b/test/browserslist/css.test.js
@@ -23,4 +23,14 @@ describe('prefixing', () => {
 
     expect(tree).toMatchSnapshot()
   })
+  test('object', () => {
+    const cls1 = css({
+      display: 'flex'
+    })
+    const tree = renderer
+      .create(<div className={cls1}>hello world</div>)
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
 })

--- a/test/macro/__snapshots__/css.test.js.snap
+++ b/test/macro/__snapshots__/css.test.js.snap
@@ -5,8 +5,6 @@ exports[`css macro composes 1`] = `
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
   justify-content: center;
 }
 
@@ -23,8 +21,6 @@ exports[`css macro composes with objects 1`] = `
   display: block;
   width: 30px;
   height: calc(40vw - 50px);
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
   justify-content: center;
 }
 
@@ -50,8 +46,6 @@ exports[`css macro composes with objects 1`] = `
 
 exports[`css macro composes with undefined values 1`] = `
 .glamor-0 {
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
   justify-content: center;
 }
 


### PR DESCRIPTION
Closes #242

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Pass filename to PostCSS correctly so browserslist can read configs correctly.

<!-- Why are these changes necessary? -->
**Why**:

#242 

<!-- How were these changes implemented? -->
**How**:

For tagged template literals: don't objectify the root node before passing it to the prefixer so that source nodes remain.
For objects: create an `Input` object and set it on the root node before passing it to the prefixer. (it's pretty hacky)

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
