### PR TITLE
Add documentation for nested selectors

### DIFF
--- a/docs/nested.md
+++ b/docs/nested.md
@@ -1,1 +1,65 @@
 ## Nested Selectors
+
+Sometimes you will want to nest selectors to target only elements inside the current class or React component. Here is an example of a simple element selector nested in the class generated with `css`:
+
+```jsx
+import { css } from 'emotion';
+
+const paragraph = css`
+  color: gray;
+
+  & a {
+    border-bottom: 1px solid currentColor;
+  }
+`;
+```
+
+For now, the `&` before the selector is required. You can also select the current class nested in another element:
+
+```jsx
+const paragraph = css`
+  color: gray;
+
+  header & {
+    color: black;
+  }
+`;
+```
+
+To nest a class selector using the class generated with `css`, simply interpolate it:
+
+```jsx
+const link = css`
+  color: hotpink;
+`;
+
+const paragraph = css`
+  color: gray;
+
+  & .${link} {
+    border-bottom: 1px solid currentColor;
+  }
+`;
+```
+
+The result of `css` is a class name _without_ the dot (`.`), so we prepended it.
+
+Similarly, in React you can nest component selectors using interpolation:
+
+```jsx
+import styled from 'emotion/react';
+
+const Link = styled.a`
+  color: hotpink;
+`;
+
+const Paragraph = styled.p`
+  color: gray;
+
+  ${Link} {
+    border-bottom: 1px solid currentColor;
+  }
+`
+```
+
+Only in the case of component selectors you should omit the `&`.


### PR DESCRIPTION
The documentation for nested selectors was missing, so I read the relevant tests and comments to figure out how it works exactly and added the documentation. I'm differentiating between three types of nested selectors:

1. regular selectors
2. class selectors from `css`
3. component selectors from `styled`

The first two require a leading `&`, but component selectors don't work that way, the `&` must be omitted. This inconsistency should probably be fixed at some point.

This is a part of #219.