### PR TITLE
Add missing macro.js to react-emotion package

### DIFF
--- a/packages/react-emotion/package.json
+++ b/packages/react-emotion/package.json
@@ -6,7 +6,8 @@
   "module": "dist/index.es.js",
   "files": [
     "src",
-    "dist"
+    "dist",
+    "macro.js"
   ],
   "scripts": {
     "build": "npm-run-all clean rollup rollup:umd",


### PR DESCRIPTION
`macro.js` exists in the source code, but not in the installed package. I don't have a lot of experience with maintaining Node modules, is this change all that's necessary to bring it back?