### PR TITLE
Remove superfluous <meta> tag from the website

### DIFF
--- a/example/src/index.tpl.html
+++ b/example/src/index.tpl.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="utf-8" />
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>emotion - The Next Generation of CSS-in-JS</title>
     <link rel="manifest" href="/manifest.json">


### PR DESCRIPTION
I don't think this tag is necessary, and the validator complains, as #120 points out.

Not that I care about HTML validation, I'm just helping with the low hanging fruit until I work my way up. 😆 

Fixes #120.