### PR TITLE
chore: update packages to deeplink into their respective directories

### DIFF
--- a/packages/babel-plugin-emotion/package.json
+++ b/packages/babel-plugin-emotion/package.json
@@ -29,10 +29,7 @@
   "author": "Kye Hohenberger",
   "homepage": "https://github.com/tkh44/emotion#readme",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/tkh44/emotion/tree/master/packages/babel-plugin-emotion"
-  },
+  "repository": "https://github.com/tkh44/emotion/tree/master/packages/babel-plugin-emotion",
   "keywords": [
     "styles",
     "emotion",

--- a/packages/babel-plugin-emotion/package.json
+++ b/packages/babel-plugin-emotion/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tkh44/emotion.git"
+    "url": "https://github.com/tkh44/emotion/tree/master/packages/babel-plugin-emotion"
   },
   "keywords": [
     "styles",

--- a/packages/babel-plugin-emotion/package.json
+++ b/packages/babel-plugin-emotion/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-emotion",
   "version": "7.1.0",
-  "description": "The Next Generation of CSS-in-JS ",
+  "description": "A recommended babel preprocessing plugin for emotion, the The Next Generation of CSS-in-JS.",
   "main": "lib/index.js",
   "files": [
     "src",

--- a/packages/emotion-server/package.json
+++ b/packages/emotion-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emotion-server",
   "version": "7.2.0",
-  "description": "The Next Generation of CSS-in-JS",
+  "description": "SSR and style extraction tooling for emotion, The Next Generation of CSS-in-JS.",
   "main": "lib/index.js",
   "files": [
     "src",
@@ -31,7 +31,9 @@
     "emotion",
     "react",
     "css",
-    "css-in-js"
+    "css-in-js",
+    "ssr",
+    "server-side-rendering"
   ],
   "bugs": {
     "url": "https://github.com/tkh44/emotion/issues"

--- a/packages/emotion-server/package.json
+++ b/packages/emotion-server/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tkh44/emotion.git"
+    "url": "https://github.com/tkh44/emotion/tree/master/packages/emotion-server"
   },
   "keywords": [
     "styles",

--- a/packages/emotion-server/package.json
+++ b/packages/emotion-server/package.json
@@ -25,10 +25,7 @@
   "author": "Kye Hohenberger",
   "homepage": "https://emotion.sh",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/tkh44/emotion/tree/master/packages/emotion-server"
-  },
+  "repository": "https://github.com/tkh44/emotion/tree/master/packages/emotion-server",
   "keywords": [
     "styles",
     "emotion",

--- a/packages/emotion-utils/package.json
+++ b/packages/emotion-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emotion-utils",
   "version": "7.1.0",
-  "description": "The Next Generation of CSS-in-JS",
+  "description": "Shared utilities used by emotion, The Next Generation of CSS-in-JS.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "files": [

--- a/packages/emotion-utils/package.json
+++ b/packages/emotion-utils/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tkh44/emotion.git"
+    "url": "https://github.com/tkh44/emotion/tree/master/packages/emotion-utils"
   },
   "keywords": [
     "styles",

--- a/packages/emotion-utils/package.json
+++ b/packages/emotion-utils/package.json
@@ -19,10 +19,7 @@
   "author": "Kye Hohenberger",
   "homepage": "https://github.com/tkh44/emotion#readme",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/tkh44/emotion/tree/master/packages/emotion-utils"
-  },
+  "repository": "https://github.com/tkh44/emotion/tree/master/packages/emotion-utils",
   "keywords": [
     "styles",
     "emotion",

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tkh44/emotion.git"
+    "url": "https://github.com/tkh44/emotion/tree/master/packages/emotion"
   },
   "keywords": [
     "styles",

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -33,10 +33,7 @@
   "author": "Kye Hohenberger",
   "homepage": "https://emotion.sh",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/tkh44/emotion/tree/master/packages/emotion"
-  },
+  "repository": "https://github.com/tkh44/emotion/tree/master/packages/emotion",
   "keywords": [
     "styles",
     "emotion",

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emotion",
   "version": "7.2.0",
-  "description": "The Next Generation of CSS-in-JS",
+  "description": "The Next Generation of CSS-in-JS.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "files": [

--- a/packages/preact-emotion/package.json
+++ b/packages/preact-emotion/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tkh44/emotion.git"
+    "url": "https://github.com/tkh44/emotion/tree/master/packages/preact-emotion"
   },
   "keywords": [
     "styles",

--- a/packages/preact-emotion/package.json
+++ b/packages/preact-emotion/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact-emotion",
   "version": "7.2.0",
-  "description": "The Next Generation of CSS-in-JS",
+  "description": "The Next Generation of CSS-in-JS, for Preact projects.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "files": [

--- a/packages/preact-emotion/package.json
+++ b/packages/preact-emotion/package.json
@@ -27,10 +27,7 @@
   "author": "Kye Hohenberger",
   "homepage": "https://github.com/tkh44/emotion#readme",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/tkh44/emotion/tree/master/packages/preact-emotion"
-  },
+  "repository": "https://github.com/tkh44/emotion/tree/master/packages/preact-emotion",
   "keywords": [
     "styles",
     "emotion",

--- a/packages/react-emotion/package.json
+++ b/packages/react-emotion/package.json
@@ -28,10 +28,7 @@
   "author": "Kye Hohenberger",
   "homepage": "https://github.com/tkh44/emotion#readme",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/tkh44/emotion/tree/master/packages/react-emotion"
-  },
+  "repository": "https://github.com/tkh44/emotion/tree/master/packages/react-emotion",
   "keywords": [
     "styles",
     "emotion",

--- a/packages/react-emotion/package.json
+++ b/packages/react-emotion/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-emotion",
   "version": "7.2.0",
-  "description": "The Next Generation of CSS-in-JS",
+  "description": "The Next Generation of CSS-in-JS, for React projects.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "files": [

--- a/packages/react-emotion/package.json
+++ b/packages/react-emotion/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tkh44/emotion.git"
+    "url": "https://github.com/tkh44/emotion/tree/master/packages/react-emotion"
   },
   "keywords": [
     "styles",


### PR DESCRIPTION
I think this makes slightly more sense than just linking to root. The visitor can always back up if they want to.

This might also be a good time to start thinking about individual package READMEs. The NPM pages are a little bare without them: https://www.npmjs.com/package/react-emotion